### PR TITLE
Fix: prevent cross-account token metadata corruption

### DIFF
--- a/upload/catalog/controller/extension/payment/amazon_ps.php
+++ b/upload/catalog/controller/extension/payment/amazon_ps.php
@@ -138,7 +138,17 @@ class ControllerExtensionPaymentAmazonPS extends Controller {
         $extras = array();
 		
         if ( isset( $this->request->post['aps_payment_token_cc'] ) && ! empty( $this->request->post['aps_payment_token_cc'] ) ) {
-            $extras['aps_payment_token'] = trim( $this->request->post['aps_payment_token_cc'], ' ' );
+            $aps_payment_token = trim( $this->request->post['aps_payment_token_cc'], ' ' );
+            // Only allow a saved card that belongs to the logged-in customer
+            if ( ! $this->aps_token->verifyTokenCustomer( $aps_payment_token, $this->customer->getId() ) ) {
+                $this->amazonpspaymentservices->log( 'Rejected saved card token not owned by customer #' . (int) $this->customer->getId(), 'send', true );
+                $this->response->setOutput( json_encode( array(
+                    'error'         => true,
+                    'error_message' => $this->language->get('error_invalid_token'),
+                ) ) );
+                return;
+            }
+            $extras['aps_payment_token'] = $aps_payment_token;
         }
         if ( isset( $this->request->post['aps_payment_card_bin_cc'] ) && ! empty( $this->request->post['aps_payment_card_bin_cc'] ) ) {
             $extras['aps_card_bin'] = trim( $this->request->post['aps_payment_card_bin_cc'], ' ' );

--- a/upload/catalog/controller/extension/payment/amazon_ps_installments.php
+++ b/upload/catalog/controller/extension/payment/amazon_ps_installments.php
@@ -148,7 +148,17 @@ class ControllerExtensionPaymentAmazonPSInstallments extends Controller {
             $installment_amount          = (float)$installment_amount;
 
             if ( isset( $this->request->post['aps_payment_token_cc'] ) && ! empty( $this->request->post['aps_payment_token_cc'] ) ) {
-                $extras['aps_payment_token'] = trim( $this->request->post['aps_payment_token_cc'], ' ' );
+                $aps_payment_token = trim( $this->request->post['aps_payment_token_cc'], ' ' );
+                // Only allow a saved card that belongs to the logged-in customer
+                if ( ! $this->aps_token->verifyTokenCustomer( $aps_payment_token, $this->customer->getId() ) ) {
+                    $this->amazonpspaymentservices->log( 'Rejected saved card token not owned by customer #' . (int) $this->customer->getId(), 'send', true );
+                    $this->response->setOutput( json_encode( array(
+                        'error'         => true,
+                        'error_message' => $this->language->get('error_invalid_token'),
+                    ) ) );
+                    return;
+                }
+                $extras['aps_payment_token'] = $aps_payment_token;
             }
             if ( isset( $this->request->post['aps_payment_card_bin_cc'] ) && ! empty( $this->request->post['aps_payment_card_bin_cc'] ) ) {
                 $extras['aps_card_bin'] = trim( $this->request->post['aps_payment_card_bin_cc'], ' ' );

--- a/upload/catalog/language/ar/extension/payment/amazon_ps.php
+++ b/upload/catalog/language/ar/extension/payment/amazon_ps.php
@@ -50,6 +50,7 @@ $_['error_invalid_expiry_date'] = "Invalid card expiry date.";
 $_['error_invalid_cvc_code'] = "Invalid CVV.";
 $_['error_invalid_cc_details'] = "Invalid credit card details, Please check you credit card details and try again.";
 $_['error_transaction_cancelled'] = 'تم إلغاء الصفقة';
+$_['error_invalid_token'] = 'البطاقة المحفوظة المحددة غير متاحة. الرجاء اختيار بطاقة مرة أخرى أو إدخال بيانات بطاقتك.';
 
 $_['help_cvc_code']      = 'You can find the code on the back of the card.';
 $_['customer_verfied']   = 'Customer Verfied';

--- a/upload/catalog/language/en-gb/extension/payment/amazon_ps.php
+++ b/upload/catalog/language/en-gb/extension/payment/amazon_ps.php
@@ -50,6 +50,7 @@ $_['error_invalid_expiry_date'] = "Invalid card expiry date.";
 $_['error_invalid_cvc_code'] = "Invalid CVV.";
 $_['error_invalid_cc_details'] = "Invalid credit card details, Please check you credit card details and try again.";
 $_['error_transaction_cancelled'] = 'Transaction Cancelled';
+$_['error_invalid_token'] = 'The selected saved card is not available. Please select a card again or enter your card details.';
 
 $_['help_cvc_code']        = 'You can find the code on the back of the card.';
 $_['customer_verfied']     = 'Customer Verfied';

--- a/upload/catalog/model/extension/payment/amazon_ps_tokens.php
+++ b/upload/catalog/model/extension/payment/amazon_ps_tokens.php
@@ -51,7 +51,13 @@ class ModelExtensionPaymentAmazonPSTokens extends Model {
     }
 
     public function insertOrUpdateGetId( $token, $customer_id ) {
-        $sql = "SELECT * FROM `" . DB_PREFIX . "amazon_ps_tokens` WHERE token = '" . $this->db->escape($token) . "'";
+        $customer_id = (int) $customer_id;
+        // Never reuse a token row that belongs to another customer
+        if ( $customer_id <= 0 ) {
+            $this->amazonpspaymentservices->log('insertOrUpdateGetId called without a valid customer_id', 'insertOrUpdateGetId', true);
+            return 0;
+        }
+        $sql = "SELECT * FROM `" . DB_PREFIX . "amazon_ps_tokens` WHERE token = '" . $this->db->escape($token) . "' and customer_id = '" . $customer_id . "'";
         $result = $this->db->query($sql);
         if ($result->num_rows > 0) {
           return (int) $result->row['ID'];
@@ -137,10 +143,12 @@ class ModelExtensionPaymentAmazonPSTokens extends Model {
         return $tokens;
     }
 
-    public function getTokenCardType($token){
+    public function getTokenCardType($token, $customer_id = null){
         $token_tbl      = DB_PREFIX . 'amazon_ps_tokens';
         $token_meta_tbl = DB_PREFIX . 'amazon_ps_token_meta_data';
-        $query_sql      = "SELECT OTM.meta_value FROM " . $token_tbl . " as OT INNER JOIN " . $token_meta_tbl . " as OTM on OT.ID = OTM.token_id where OT.token ='". $this->db->escape($token) ."' and OTM.meta_key = 'card_type' LIMIT 1";
+        // when a customer is supplied, only read the card type from that customer's own token row
+        $customer_filter = ( null === $customer_id ) ? '' : " and OT.customer_id = '" . (int) $customer_id . "'";
+        $query_sql      = "SELECT OTM.meta_value FROM " . $token_tbl . " as OT INNER JOIN " . $token_meta_tbl . " as OTM on OT.ID = OTM.token_id where OT.token ='". $this->db->escape($token) ."'" . $customer_filter . " and OTM.meta_key = 'card_type' LIMIT 1";
         $result = $this->db->query($query_sql);
         if($result->num_rows){
             return $result->row['meta_value'];
@@ -160,10 +168,11 @@ class ModelExtensionPaymentAmazonPSTokens extends Model {
     public function deleteToken($token, $customer_id){
         $token_id = $this->verifyTokenCustomer($token, $customer_id);
         if($token_id){
-            $sql = "DELETE FROM `" . DB_PREFIX . "amazon_ps_tokens` WHERE token='" . $this->db->escape($token) . "' and customer_id = '".$this->db->escape($customer_id)."'";
+            $sql = "DELETE FROM `" . DB_PREFIX . "amazon_ps_tokens` WHERE ID = " . (int) $token_id;
             $result = $this->db->query($sql);
 
-            $sql = "DELETE FROM `" . DB_PREFIX . "amazon_ps_token_meta_data` WHERE token_id='" . $this->db->escape($token) . "'";
+            // meta rows are keyed by the numeric token row ID, not the token string
+            $sql = "DELETE FROM `" . DB_PREFIX . "amazon_ps_token_meta_data` WHERE token_id = " . (int) $token_id;
             $result = $this->db->query($sql);
         }
     }

--- a/upload/catalog/view/javascript/amazon_ps/amazon_ps_checkout.js
+++ b/upload/catalog/view/javascript/amazon_ps/amazon_ps_checkout.js
@@ -393,6 +393,39 @@ var APSValidation = {
 	filterInput: function(user_input) {
 		user_input = $.trim(user_input);
 		return user_input.replace(/[^a-z0-9 ]/gi, '');
+	},
+	// Show a payment error where the shopper can actually see it.
+	// Falls back through the containers that exist across the different
+	// checkout templates, so the message is never silently dropped.
+	showPaymentError: function(message) {
+		if (!message) {
+			message = (typeof text_general_error !== 'undefined') ? text_general_error : '';
+		}
+		var alert_html = '<div class="alert alert-danger alert-dismissible aps_payment_error">' + message +
+			'<button type="button" class="close" data-dismiss="alert">&times;</button></div>';
+
+		$('.aps_payment_error').remove();
+
+		var $target = $('#installment_plans .plans');
+		if (!$target.length) {
+			$target = $('#em_installment_plans');
+		}
+		if (!$target.length) {
+			$target = $('.token-box');
+		}
+		if ($target.length) {
+			$target.first().append(alert_html);
+		} else if ($('#button-confirm').length) {
+			$('#button-confirm').closest('.buttons').before(alert_html);
+		} else {
+			alert(message);
+			return;
+		}
+
+		var $shown = $('.aps_payment_error').first();
+		if ($shown.length && $shown.offset()) {
+			$('html, body').animate({ scrollTop: $shown.offset().top - 50 }, 500);
+		}
 	}
 }
 var AmazonPSCall = {
@@ -446,8 +479,8 @@ var AmazonPSCall = {
 				}
 				var aps_input_token_cc        = APSValidation.filterInput($('input[name=aps_payment_token_cc]:checked').val());
 				var aps_input_saved_card_code = APSValidation.filterInput($('input[name=aps_saved_card_security_code]').val());
-				var aps_input_token_cc        = APSValidation.filterInput($('input[name=aps_payment_token_cc]:checked').data('cardbin'));
-				var fdama = `aps_payment_token_cc=${aps_input_token_cc}&aps_card_security_code=${aps_input_saved_card_code}&aps_payment_card_bin_cc=${aps_input_token_cc}`;
+				var aps_input_card_bin_cc     = APSValidation.filterInput($('input[name=aps_payment_token_cc]:checked').data('cardbin'));
+				var fdama = `aps_payment_token_cc=${encodeURIComponent(aps_input_token_cc)}&aps_card_security_code=${encodeURIComponent(aps_input_saved_card_code)}&aps_payment_card_bin_cc=${encodeURIComponent(aps_input_card_bin_cc)}`;
 
 			}
 			else{
@@ -469,8 +502,11 @@ var AmazonPSCall = {
 				success: function (json) {
 					json = JSON.parse(json);
 					if (json['error']) {
+						// re-enable the button the shopper actually clicked, otherwise
+						// checkout stays dead with no way to retry
+						$('#button-confirm').attr('disabled', false);
 						$('#button-payment-method').button('reset');
-						$('#installment_plans .plans').append('<div class="alert alert-danger alert-dismissible">' + json['error_message'] + '<button type="button" class="close" data-dismiss="alert">&times;</button></div>');
+						APSValidation.showPaymentError(json['error_message']);
 					}
 					else if (json) {
 						if('standard_checkout' == payment_integration_type){

--- a/upload/catalog/view/theme/default/template/extension/payment/amazon_ps.twig
+++ b/upload/catalog/view/theme/default/template/extension/payment/amazon_ps.twig
@@ -25,7 +25,17 @@ $('#button-confirm').bind('click', function () {
         },
         success: function (json) {
 
-            if (json['form']) {
+            $('.aps_payment_error').remove();
+
+            if (json['error']) {
+                var msg = json['error_message'] ? json['error_message'] : '{{ text_general_error }}';
+                $('<div class="alert alert-danger alert-dismissible aps_payment_error"></div>')
+                    .text(msg)
+                    .append('<button type="button" class="close" data-dismiss="alert">&times;</button>')
+                    .insertBefore($('#button-confirm').closest('.buttons'));
+            }
+
+            else if (json['form']) {
                 $('body').append(json['form']);
                 $('#frm_payfort_fort_payment input[type=submit]').click();
             }

--- a/upload/system/library/amazonpsorderpayment.php
+++ b/upload/system/library/amazonpsorderpayment.php
@@ -388,7 +388,7 @@ class AmazonPSOrderPayment {
         }
 
         if ( isset( $apsParams['token_name'] ) && ! empty( $apsParams['token_name'] ) ) {
-            $card_type = $this->aps_token->getTokenCardType($apsParams['token_name']);
+            $card_type = $this->aps_token->getTokenCardType($apsParams['token_name'], isset($order['customer_id']) ? $order['customer_id'] : null);
                 if ( ! empty( $card_type ) ) {
                     $command = $this->amazonpspaymentservices->getCommand( $paymentMethod, null, strtoupper( $card_type ) );
                 }


### PR DESCRIPTION
  Saved-card tokens were looked up by token string alone, so one customer could reuse, read, or overwrite another's token. This scopes all token access by customer_id:              
                                                                                                                                                                                     
  - Controllers (amazon_ps.php, amazon_ps_installments.php): call verifyTokenCustomer() before using a posted token; reject with logged error_invalid_token if not owned by the      
    current customer.                                                                                                                                                                
  - Model (amazon_ps_tokens.php): insertOrUpdateGetId() adds customer_id filter + int-guard; getTokenCardType() takes optional customer_id filter; deleteToken() now deletes by      
    numeric token_id — fixing a bug where meta rows (keyed wrongly by token string) were never deleted.                                                                              
  - Library (amazonpsorderpayment.php): passes customer_id into getTokenCardType().                                                                                                  
  - JS/twig: new showPaymentError() surfaces errors visibly and re-enables the confirm button; fixes a bug where token was overwritten by card BIN; adds encodeURIComponent()        
    escaping.                                                                                                                                                                        
  - Language files: add error_invalid_token (en + ar).